### PR TITLE
Bug/fix migrate error

### DIFF
--- a/db/migrate/20180525085041_create_users.rb
+++ b/db/migrate/20180525085041_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration[4.0]
+class CreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table :users do |t|
       t.string :name

--- a/db/migrate/20180528024113_create_posts.rb
+++ b/db/migrate/20180528024113_create_posts.rb
@@ -1,4 +1,4 @@
-class CreatePosts < ActiveRecord::Migration[4.0]
+class CreatePosts < ActiveRecord::Migration[4.2]
   def change
     create_table :posts do |t|
       t.string :title

--- a/db/migrate/20180528024517_create_categories.rb
+++ b/db/migrate/20180528024517_create_categories.rb
@@ -1,4 +1,4 @@
-class CreateCategories < ActiveRecord::Migration[4.0]
+class CreateCategories < ActiveRecord::Migration[4.2]
   def change
     create_table :categories do |t|
       t.string :name

--- a/db/migrate/20180529035925_create_comments.rb
+++ b/db/migrate/20180529035925_create_comments.rb
@@ -1,4 +1,4 @@
-class CreateComments < ActiveRecord::Migration[4.0]
+class CreateComments < ActiveRecord::Migration[4.2]
   def change
     create_table :comments do |t|
       t.text :body

--- a/db/migrate/20180728050317_add_thumbnail_to_posts.rb
+++ b/db/migrate/20180728050317_add_thumbnail_to_posts.rb
@@ -1,4 +1,4 @@
-class AddThumbnailToPosts < ActiveRecord::Migration[4.0]
+class AddThumbnailToPosts < ActiveRecord::Migration[4.2]
   def change
     add_column :posts, :thumbnail, :string
   end

--- a/db/migrate/20180728190538_create_ckeditor_assets.rb
+++ b/db/migrate/20180728190538_create_ckeditor_assets.rb
@@ -1,4 +1,4 @@
-class CreateCkeditorAssets < ActiveRecord::Migration[4.0]
+class CreateCkeditorAssets < ActiveRecord::Migration[4.2]
   def self.up
     create_table :ckeditor_assets do |t|
       t.string  :data_file_name, null: false

--- a/db/migrate/20180728190539_add_summary_to_posts.rb
+++ b/db/migrate/20180728190539_add_summary_to_posts.rb
@@ -1,4 +1,4 @@
-class AddSummaryToPosts < ActiveRecord::Migration[4.0]
+class AddSummaryToPosts < ActiveRecord::Migration[4.2]
   def change
     add_column :posts, :summary, :string
   end

--- a/db/migrate/20180730003810_create_employees.rb
+++ b/db/migrate/20180730003810_create_employees.rb
@@ -1,4 +1,4 @@
-class CreateEmployees < ActiveRecord::Migration[4.0]
+class CreateEmployees < ActiveRecord::Migration[4.2]
   def change
     create_table :employees do |t|
       t.string :name

--- a/db/migrate/20180730004230_add_image_to_employees.rb
+++ b/db/migrate/20180730004230_add_image_to_employees.rb
@@ -1,4 +1,4 @@
-class AddImageToEmployees < ActiveRecord::Migration[4.0]
+class AddImageToEmployees < ActiveRecord::Migration[4.2]
   def change
     add_column :employees, :image, :string
   end

--- a/db/migrate/20180802131309_create_galleries.rb
+++ b/db/migrate/20180802131309_create_galleries.rb
@@ -1,4 +1,4 @@
-class CreateGalleries < ActiveRecord::Migration[4.0]
+class CreateGalleries < ActiveRecord::Migration[4.2]
   def change
     create_table :galleries do |t|
       t.string :title

--- a/db/migrate/20180803152305_create_gallery_images.rb
+++ b/db/migrate/20180803152305_create_gallery_images.rb
@@ -1,4 +1,4 @@
-class CreateGalleryImages < ActiveRecord::Migration[4.0]
+class CreateGalleryImages < ActiveRecord::Migration[4.2]
   def change
     create_table :gallery_images do |t|
       t.string :image

--- a/db/migrate/20180804152448_add_name_and_email_to_comments.rb
+++ b/db/migrate/20180804152448_add_name_and_email_to_comments.rb
@@ -1,4 +1,4 @@
-class AddNameAndEmailToComments < ActiveRecord::Migration[4.0]
+class AddNameAndEmailToComments < ActiveRecord::Migration[4.2]
   def change
     add_column :comments, :name, :string
     add_column :comments, :email, :string

--- a/db/migrate/20180804153347_add_post_id_to_comments.rb
+++ b/db/migrate/20180804153347_add_post_id_to_comments.rb
@@ -1,4 +1,4 @@
-class AddPostIdToComments < ActiveRecord::Migration[4.0]
+class AddPostIdToComments < ActiveRecord::Migration[4.2]
   def change
     add_column :comments, :post_id, :integer
   end

--- a/db/migrate/20180829153859_add_sort_to_employees.rb
+++ b/db/migrate/20180829153859_add_sort_to_employees.rb
@@ -1,4 +1,4 @@
-class AddSortToEmployees < ActiveRecord::Migration[4.0]
+class AddSortToEmployees < ActiveRecord::Migration[4.2]
   def change
     add_column :employees, :sort, :integer
   end

--- a/db/migrate/20180903033117_create_events.rb
+++ b/db/migrate/20180903033117_create_events.rb
@@ -1,4 +1,4 @@
-class CreateEvents < ActiveRecord::Migration[4.0]
+class CreateEvents < ActiveRecord::Migration[4.2]
   def change
     create_table :events do |t|
       t.string :title

--- a/db/migrate/20180912113058_add_model_type_to_categories.rb
+++ b/db/migrate/20180912113058_add_model_type_to_categories.rb
@@ -1,4 +1,4 @@
-class AddModelTypeToCategories < ActiveRecord::Migration[4.0]
+class AddModelTypeToCategories < ActiveRecord::Migration[4.2]
   def change
     add_column :categories, :model_type, :integer, default: 0, index: true
   end

--- a/db/migrate/20180912142734_add_category_id_to_events.rb
+++ b/db/migrate/20180912142734_add_category_id_to_events.rb
@@ -1,4 +1,4 @@
-class AddCategoryIdToEvents < ActiveRecord::Migration[4.0]
+class AddCategoryIdToEvents < ActiveRecord::Migration[4.2]
   def change
     add_reference :events, :category, index: true
   end

--- a/db/migrate/20180917043011_create_static_pages.rb
+++ b/db/migrate/20180917043011_create_static_pages.rb
@@ -1,4 +1,4 @@
-class CreateStaticPages < ActiveRecord::Migration[4.0]
+class CreateStaticPages < ActiveRecord::Migration[4.2]
   def change
     create_table :static_pages do |t|
       t.text :body

--- a/db/migrate/20180917044441_add_name_to_static_pages.rb
+++ b/db/migrate/20180917044441_add_name_to_static_pages.rb
@@ -1,4 +1,4 @@
-class AddNameToStaticPages < ActiveRecord::Migration[4.0]
+class AddNameToStaticPages < ActiveRecord::Migration[4.2]
   def change
     add_column :static_pages, :name, :string
   end

--- a/db/migrate/20180917083609_add_slug_to_static_pages.rb
+++ b/db/migrate/20180917083609_add_slug_to_static_pages.rb
@@ -1,4 +1,4 @@
-class AddSlugToStaticPages < ActiveRecord::Migration[4.0]
+class AddSlugToStaticPages < ActiveRecord::Migration[4.2]
   def change
     add_column :static_pages, :slug, :string
   end

--- a/db/migrate/20181107153208_add_published_at_to_posts.rb
+++ b/db/migrate/20181107153208_add_published_at_to_posts.rb
@@ -1,4 +1,4 @@
-class AddPublishedAtToPosts < ActiveRecord::Migration[4.0]
+class AddPublishedAtToPosts < ActiveRecord::Migration[4.2]
   def change
     add_column :posts, :published_at, :datetime
   end

--- a/db/migrate/20181107153519_add_published_at_to_events.rb
+++ b/db/migrate/20181107153519_add_published_at_to_events.rb
@@ -1,4 +1,4 @@
-class AddPublishedAtToEvents < ActiveRecord::Migration[4.0]
+class AddPublishedAtToEvents < ActiveRecord::Migration[4.2]
   def change
     add_column :events, :published_at, :datetime
   end

--- a/db/migrate/20181107153528_add_published_at_to_galleries.rb
+++ b/db/migrate/20181107153528_add_published_at_to_galleries.rb
@@ -1,4 +1,4 @@
-class AddPublishedAtToGalleries < ActiveRecord::Migration[4.0]
+class AddPublishedAtToGalleries < ActiveRecord::Migration[4.2]
   def change
     add_column :galleries, :published_at, :datetime
   end

--- a/db/migrate/20181231131314_create_videos.rb
+++ b/db/migrate/20181231131314_create_videos.rb
@@ -1,4 +1,4 @@
-class CreateVideos < ActiveRecord::Migration[4.0]
+class CreateVideos < ActiveRecord::Migration[4.2]
   def change
     create_table :videos do |t|
       t.string :title

--- a/db/migrate/20190114103630_add_published_at_to_videos.rb
+++ b/db/migrate/20190114103630_add_published_at_to_videos.rb
@@ -1,4 +1,4 @@
-class AddPublishedAtToVideos < ActiveRecord::Migration[4.0]
+class AddPublishedAtToVideos < ActiveRecord::Migration[4.2]
   def change
     add_column :videos, :published_at, :datetime
   end

--- a/db/migrate/20190114145250_remove_slug_from_posts.rb
+++ b/db/migrate/20190114145250_remove_slug_from_posts.rb
@@ -1,4 +1,4 @@
-class RemoveSlugFromPosts < ActiveRecord::Migration[4.0]
+class RemoveSlugFromPosts < ActiveRecord::Migration[4.2]
   def change
     remove_column :posts, :slug, :string
   end

--- a/db/migrate/20190114145657_add_slug_to_posts.rb
+++ b/db/migrate/20190114145657_add_slug_to_posts.rb
@@ -1,4 +1,4 @@
-class AddSlugToPosts < ActiveRecord::Migration[4.0]
+class AddSlugToPosts < ActiveRecord::Migration[4.2]
   def change
     add_column :posts, :slug, :string
     add_index :posts, :slug, unique: true

--- a/db/migrate/20190114145707_add_slug_to_events.rb
+++ b/db/migrate/20190114145707_add_slug_to_events.rb
@@ -1,4 +1,4 @@
-class AddSlugToEvents < ActiveRecord::Migration[4.0]
+class AddSlugToEvents < ActiveRecord::Migration[4.2]
   def change
     add_column :events, :slug, :string
     add_index :events, :slug, unique: true

--- a/db/migrate/20190114145716_add_slug_to_videos.rb
+++ b/db/migrate/20190114145716_add_slug_to_videos.rb
@@ -1,4 +1,4 @@
-class AddSlugToVideos < ActiveRecord::Migration[4.0]
+class AddSlugToVideos < ActiveRecord::Migration[4.2]
   def change
     add_column :videos, :slug, :string
     add_index :videos, :slug, unique: true

--- a/db/migrate/20190114145744_add_slug_to_galleries.rb
+++ b/db/migrate/20190114145744_add_slug_to_galleries.rb
@@ -1,4 +1,4 @@
-class AddSlugToGalleries < ActiveRecord::Migration[4.0]
+class AddSlugToGalleries < ActiveRecord::Migration[4.2]
   def change
     add_column :galleries, :slug, :string
     add_index :galleries, :slug, unique: true


### PR DESCRIPTION
## Why the changes?
After upgrading to Rails 5, we need to specify the rails version on past migration file, else it will give an error.

## What are the changes?
Rails version 4.2 is specified in all past migration file
Eg.
```
class CreatePosts < ActiveRecord::Migration
```
to
```
class CreatePosts < ActiveRecord::Migration[4.2]
```

