### PR TITLE
[BUG] Fix Cannot Add Gallery Image

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ group :development do
   gem "capistrano-rbenv"
 
   # Access an IRB console on exception pages or by using <%= console %> in views
-  gem 'web-console', '~> 2.0'
+  gem 'web-console', '>= 2.5.0'
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,8 +65,7 @@ GEM
     aws_cf_signer (0.1.3)
     bcrypt (3.1.12)
     bcrypt_pbkdf (1.0.0)
-    binding_of_caller (0.8.0)
-      debug_inspector (>= 0.0.1)
+    bindex (0.8.1)
     bootsnap (1.4.4)
       msgpack (~> 1.0)
     builder (3.2.3)
@@ -106,7 +105,6 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
-    debug_inspector (0.0.3)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.5.0)
@@ -259,11 +257,11 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
-    web-console (2.3.0)
-      activemodel (>= 4.0)
-      binding_of_caller (>= 0.7.2)
-      railties (>= 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
+    web-console (3.7.0)
+      actionview (>= 5.0)
+      activemodel (>= 5.0)
+      bindex (>= 0.4.0)
+      railties (>= 5.0)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -310,7 +308,7 @@ DEPENDENCIES
   social-share-button!
   spring
   uglifier (>= 1.3.0)
-  web-console (~> 2.0)
+  web-console (>= 2.5.0)
   will_paginate (~> 3.1.7)
 
 BUNDLED WITH


### PR DESCRIPTION
### Why the changes?
There is a bug that prevents adding image to a gallery

### What are the changes?
- Updated `web-console` gem to from `2.3.0` to `2.5.0` due to `Mime::HTML` error

### Additional Note
- `~/.netrc` file permission should be `0600`